### PR TITLE
Drop multiple tokens for single actor.

### DIFF
--- a/src/ts/canvas/single-actor-drop-handler.ts
+++ b/src/ts/canvas/single-actor-drop-handler.ts
@@ -1,0 +1,301 @@
+import { DroppableHandler } from "../droppable.ts";
+import { Settings } from "../settings.ts";
+import { translateToTopLeftGrid } from "../util.ts";
+
+const { DialogV2 } = foundry.applications.api;
+const { renderTemplate } = foundry.applications.handlebars;
+const { TextEditor } = foundry.applications.ux;
+
+interface ActorDropData {
+    type: string;
+    uuid: string;
+    x: number;
+    y: number;
+    elevation?: number;
+}
+
+interface DropManyInput {
+    actors: Actor[];
+    xPosition: number;
+    yPosition: number;
+    elevation?: number;
+    isHidden: boolean;
+    isHorizontal?: boolean;
+}
+
+class SingleActorDropHandler implements DroppableHandler<ActorDropData> {
+    data: ActorDropData;
+
+    #event: DragEvent;
+    #settings = new Settings();
+
+    constructor(event: DragEvent) {
+        this.#event = event;
+        this.data = this.retrieveData();
+    }
+
+    canHandleDrop(): boolean {
+        return this.data.type === "Actor";
+    }
+
+    retrieveData(): ActorDropData {
+        const json = TextEditor.getDragEventData(this.#event);
+        return {
+            type: json["type"] as string,
+            uuid: json["uuid"] as string,
+            x: json["x"] as number,
+            y: json["y"] as number,
+            elevation: json["elevation"] as number | undefined,
+        };
+    }
+
+    async handleDrop(): Promise<boolean> {
+        if (!this.canHandleDrop()) return false;
+        this.#event.preventDefault();
+
+        const actor = (await fromUuid(this.data.uuid)) as Actor | null;
+        if (!actor) return false;
+
+        const topLeft = translateToTopLeftGrid(this.#event);
+        const xPosition: number = this.data.x ?? topLeft.x;
+        const yPosition: number = this.data.y ?? topLeft.y;
+        const elevation: number = this.data.elevation ?? 0;
+        const isHidden = this.#event.altKey;
+
+        // If not NPC, just drop a single token without dialog
+        if (actor.type !== "npc") {
+            await this.#dropActor({
+                actor,
+                xPosition,
+                yPosition,
+                isHidden,
+                elevation,
+            });
+            return true;
+        }
+
+        // NPC: show dialog with count input
+        const dropStyles = [
+            { value: "stack", label: game.i18n.localize("Droppables.StackedUp") },
+            { value: "random", label: game.i18n.localize("Droppables.Randomly") },
+            {
+                value: "horizontalLine",
+                label: game.i18n.localize("Droppables.HorizontalLine"),
+            },
+            {
+                value: "verticalLine",
+                label: game.i18n.localize("Droppables.VerticalLine"),
+            },
+        ];
+
+        const content = await renderTemplate(
+            "modules/dfreds-droppables/templates/drop-dialog.hbs",
+            {
+                dropStyles,
+                savedDropStyle: this.#settings.lastUsedDropStyle,
+                startingElevation: elevation ? Math.round(elevation) : null,
+                allowCount: true,
+                defaultCount: 1,
+            },
+        );
+
+        await DialogV2.confirm({
+            window: {
+                title: game.i18n.localize("Droppables.DropActorsFolder"),
+                controls: [],
+            },
+            content,
+            position: { width: 320 },
+            yes: {
+                icon: "fas fa-level-down-alt",
+                label: game.i18n.localize("Droppables.DropButton"),
+                callback: async (_event, _button, dialog) => {
+                    const $html = $(dialog.element);
+                    const dropStyle = $html.find('select[name="drop-style"]').val();
+                    const dropElevation = parseFloat(
+                        $html.find('input[name="elevation"]').val() as string,
+                    );
+                    const countRaw = parseInt(
+                        ($html.find('input[name="count"]').val() as string) ?? "1",
+                        10,
+                    );
+                    const count = Math.max(1, Number.isNaN(countRaw) ? 1 : countRaw);
+
+                    this.#settings.lastUsedDropStyle = dropStyle as string;
+
+                    const actors = Array.from({ length: count }, () => actor);
+
+                    if (dropStyle === "stack") {
+                        await this.#dropStack({
+                            actors,
+                            xPosition,
+                            yPosition,
+                            isHidden,
+                            elevation: dropElevation,
+                        });
+                    } else if (dropStyle === "random") {
+                        await this.#dropRandom({
+                            actors,
+                            xPosition,
+                            yPosition,
+                            isHidden,
+                            elevation: dropElevation,
+                        });
+                    } else if (dropStyle === "horizontalLine") {
+                        await this.#dropLine({
+                            isHorizontal: true,
+                            actors,
+                            xPosition,
+                            yPosition,
+                            isHidden,
+                            elevation: dropElevation,
+                        });
+                    } else if (dropStyle === "verticalLine") {
+                        await this.#dropLine({
+                            isHorizontal: false,
+                            actors,
+                            xPosition,
+                            yPosition,
+                            isHidden,
+                            elevation: dropElevation,
+                        });
+                    }
+                },
+            },
+        });
+
+        return true;
+    }
+
+    async #dropStack({
+        actors,
+        xPosition,
+        yPosition,
+        isHidden,
+        elevation = undefined,
+    }: DropManyInput) {
+        for (const actor of actors) {
+            await this.#dropActor({
+                actor,
+                xPosition,
+                yPosition,
+                isHidden,
+                elevation,
+            });
+        }
+    }
+
+    async #dropRandom({
+        actors,
+        xPosition,
+        yPosition,
+        isHidden,
+        elevation = undefined,
+    }: DropManyInput) {
+        let distance = 0;
+        let dropped = 0;
+        let offsetX = 0;
+        let offsetY = 0;
+
+        for (const actor of actors) {
+            const totalTries =
+                Math.pow(1 + distance * 2, 2) - Math.pow(distance * 2 - 1, 2);
+
+            const tries = Math.pow(1 + distance * 2, 2) - dropped;
+
+            await this.#dropActor({
+                actor,
+                xPosition: xPosition + offsetX,
+                yPosition: yPosition + offsetY,
+                isHidden,
+                elevation,
+            });
+
+            if (totalTries - tries < totalTries / 4) {
+                offsetX += canvas.grid.sizeX;
+            } else if (totalTries - tries < (2 * totalTries) / 4) {
+                offsetY += canvas.grid.sizeY;
+            } else if (totalTries - tries < (3 * totalTries) / 4) {
+                offsetX -= canvas.grid.sizeX;
+            } else {
+                offsetY -= canvas.grid.sizeY;
+            }
+
+            dropped += 1;
+
+            if (dropped === Math.pow(1 + distance * 2, 2)) {
+                distance += 1;
+                offsetX = -1 * distance * canvas.grid.sizeX;
+                offsetY = -1 * distance * canvas.grid.sizeY;
+            }
+        }
+    }
+
+    async #dropLine({
+        isHorizontal,
+        actors,
+        xPosition,
+        yPosition,
+        isHidden,
+        elevation = undefined,
+    }: DropManyInput) {
+        const step = isHorizontal ? canvas.grid.sizeX : canvas.grid.sizeY;
+
+        let offsetX = 0;
+        let offsetY = 0;
+
+        for (const actor of actors) {
+            const width =
+                (foundry.utils.getProperty(
+                    actor,
+                    "prototypeToken.width",
+                ) as number) || 1;
+            const height =
+                (foundry.utils.getProperty(
+                    actor,
+                    "prototypeToken.height",
+                ) as number) || 1;
+
+            await this.#dropActor({
+                actor,
+                xPosition: xPosition + offsetX,
+                yPosition: yPosition + offsetY,
+                isHidden,
+                elevation,
+            });
+
+            if (isHorizontal) {
+                offsetX += width * step;
+            } else {
+                offsetY += height * step;
+            }
+        }
+    }
+
+    async #dropActor({
+        actor,
+        xPosition,
+        yPosition,
+        isHidden,
+        elevation,
+    }: {
+        actor: Actor;
+        xPosition: number;
+        yPosition: number;
+        isHidden: boolean;
+        elevation?: number;
+    }): Promise<TokenDocument | undefined> {
+        const tokenDocument = await actor.getTokenDocument({
+            x: xPosition,
+            y: yPosition,
+            hidden: isHidden,
+            elevation: Number.isNaN(elevation) ? 0 : elevation,
+        });
+
+        const token = new CONFIG.Token.documentClass(tokenDocument);
+        return TokenDocument.create(token.toObject(), { parent: canvas.scene });
+    }
+}
+
+export { SingleActorDropHandler };
+export type { ActorDropData };

--- a/src/ts/canvas/single-actor-drop-handler.ts
+++ b/src/ts/canvas/single-actor-drop-handler.ts
@@ -62,8 +62,11 @@ class SingleActorDropHandler implements DroppableHandler<ActorDropData> {
         const elevation: number = this.data.elevation ?? 0;
         const isHidden = this.#event.altKey;
 
-        // If not NPC, just drop a single token without dialog
-        if (actor.type !== "npc") {
+        // Show dialog only for unlinked NPCs. For all others, drop a single token immediately.
+        const isNpc = actor.type === "npc";
+        const isLinked = Boolean(foundry.utils.getProperty(actor, "prototypeToken.actorLink"));
+
+        if (!isNpc || isLinked) {
             await this.#dropActor({
                 actor,
                 xPosition,
@@ -74,7 +77,7 @@ class SingleActorDropHandler implements DroppableHandler<ActorDropData> {
             return true;
         }
 
-        // NPC: show dialog with count input
+        // Unlinked NPC: show dialog with count input
         const dropStyles = [
             { value: "stack", label: game.i18n.localize("Droppables.StackedUp") },
             { value: "random", label: game.i18n.localize("Droppables.Randomly") },

--- a/src/ts/canvas/single-actor-drop-handler.ts
+++ b/src/ts/canvas/single-actor-drop-handler.ts
@@ -98,7 +98,6 @@ class SingleActorDropHandler implements DroppableHandler<ActorDropData> {
                 savedDropStyle: this.#settings.lastUsedDropStyle,
                 startingElevation: elevation ? Math.round(elevation) : null,
                 allowCount: true,
-                defaultCount: 1,
             },
         );
 

--- a/src/ts/hooks/canvasInit.ts
+++ b/src/ts/hooks/canvasInit.ts
@@ -5,6 +5,7 @@ import { Listener } from "./index.ts";
 import { TilesOnCanvasHandler } from "../canvas/tiles-on-canvas-handler.ts";
 import { SoundsOnCanvasHandler } from "../canvas/sounds-on-canvas-handler.ts";
 import { NotesOnCanvasHandler } from "../canvas/notes-on-canvas-handler.ts";
+import { SingleActorDropHandler } from "../canvas/single-actor-drop-handler.ts";
 
 const CanvasInit: Listener = {
     listen(): void {
@@ -19,6 +20,7 @@ const CanvasInit: Listener = {
             board.ondrop = async (event: DragEvent) => {
                 const manager = new DroppableManager();
 
+                manager.registerHandler(new SingleActorDropHandler(event));
                 manager.registerHandler(new FolderDropHandler(event));
                 manager.registerHandler(new TokensOnCanvasHandler(event));
                 manager.registerHandler(new TilesOnCanvasHandler(event));

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -34,6 +34,7 @@
         "SettingDropStyleVerticalLine": "Vertical Line",
 
         "SettingEnableCanvasDragUpload": "Enable Canvas Drag/Upload",
-        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer."
+        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer.",
+        "CountForSingleToken": "How many tokens?"
     }
 }

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -27,6 +27,7 @@
         "SettingDropStyleVerticalLine": "Línea Vertical",
 
         "SettingEnableCanvasDragUpload": "Enable Canvas Drag/Upload (Translation Needed)",
-        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer. (Translation Needed)"
+        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer. (Translation Needed)",
+        "CountForSingleToken": "¿Cuántos tokens?"
     }
 }

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -27,6 +27,7 @@
         "SettingDropStyleVerticalLine": "Ligne verticale",
 
         "SettingEnableCanvasDragUpload": "Enable Canvas Drag/Upload (Translation Needed)",
-        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer. (Translation Needed)"
+        "SettingEnableCanvasDragUploadHint": "If enabled, you can drag and upload tokens, tiles, audio, and journal entries onto the canvas based on the selected layer. (Translation Needed)",
+        "CountForSingleToken": "Combien de jetons?"
     }
 }

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -34,6 +34,7 @@
         "SettingDropStyleVerticalLine": "上から下へ",
 
         "SettingEnableCanvasDragUpload": "マップにドラッグ/アップロード有効化",
-        "SettingEnableCanvasDragUploadHint": "有効にすると、コマ・タイル・音声・資料を、選択中のレイヤーに基づいてマップ上にドラッグ&アップロードできます。"
+        "SettingEnableCanvasDragUploadHint": "有効にすると、コマ・タイル・音声・資料を、選択中のレイヤーに基づいてマップ上にドラッグ&アップロードできます。",
+        "CountForSingleToken": "コマをいくつ配置しますか？"
     }
 }

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -27,6 +27,7 @@
         "SettingDropStyleVerticalLine": "Linha Vertical",
 
         "SettingEnableCanvasDragUpload": "Habilitar Arrastar/Carregar na Tela",
-        "SettingEnableCanvasDragUploadHint": "Se habilitado, você pode arrastar e carregar tokens, peças, áudios e entradas do diário na tela baseado na camada selecionada."
+        "SettingEnableCanvasDragUploadHint": "Se habilitado, você pode arrastar e carregar tokens, peças, áudios e entradas do diário na tela baseado na camada selecionada.",
+        "CountForSingleToken": "Quantos tokens?"
     }
 }

--- a/static/templates/drop-dialog.hbs
+++ b/static/templates/drop-dialog.hbs
@@ -4,6 +4,23 @@
     onsubmit="event.preventDefault();"
 >
     <p>{{localize "Droppables.DropExplanation"}}</p>
+    {{#if allowCount}}
+        <div class="form-group">
+            <label for="count">{{localize "Droppables.CountForSingleToken"}}</label>
+            <div class="form-fields">
+                <input
+                    type="number"
+                    id="count"
+                    name="count"
+                    min="1"
+                    step="1"
+                    placeholder="{{defaultCount}}"
+                    value=""
+                    autofocus
+                />
+            </div>
+        </div>
+    {{/if}}
     <div class="form-group">
         <label class="droppables-dialog-label" for="drop-style">{{localize
                 "Droppables.DropStyle"
@@ -31,21 +48,4 @@
             />
         </div>
     </div>
-    {{#if allowCount}}
-    <div class="form-group">
-        <label for="count">{{localize "Droppables.Count"}}</label>
-        <div class="form-fields">
-            <input
-                type="number"
-                id="count"
-                name="count"
-                min="1"
-                step="1"
-                placeholder="{{defaultCount}}"
-                value=""
-                autofocus
-            />
-        </div>
-    </div>
-    {{/if}}
 </form>

--- a/static/templates/drop-dialog.hbs
+++ b/static/templates/drop-dialog.hbs
@@ -14,7 +14,7 @@
                     name="count"
                     min="1"
                     step="1"
-                    placeholder="{{defaultCount}}"
+                    placeholder="1"
                     value=""
                     autofocus
                 />

--- a/static/templates/drop-dialog.hbs
+++ b/static/templates/drop-dialog.hbs
@@ -5,11 +5,11 @@
 >
     <p>{{localize "Droppables.DropExplanation"}}</p>
     <div class="form-group">
-        <label class="droppables-dialog-label">{{localize
+        <label class="droppables-dialog-label" for="drop-style">{{localize
                 "Droppables.DropStyle"
             }}</label>
         <div class="form-fields">
-            <select name="drop-style" autofocus>
+            <select id="drop-style" name="drop-style"{{#unless allowCount}} autofocus{{/unless}}>
                 {{selectOptions
                     dropStyles
                     selected=savedDropStyle
@@ -20,9 +20,10 @@
         </div>
     </div>
     <div class="form-group">
-        <label>{{localize "Droppables.Elevation"}}</label>
+        <label for="elevation">{{localize "Droppables.Elevation"}}</label>
         <div class="form-fields">
             <input
+                id="elevation"
                 type="number"
                 name="elevation"
                 placeholder="{{localize 'Droppables.ElevationOptional'}}"
@@ -30,4 +31,21 @@
             />
         </div>
     </div>
+    {{#if allowCount}}
+    <div class="form-group">
+        <label for="count">{{localize "Droppables.Count"}}</label>
+        <div class="form-fields">
+            <input
+                type="number"
+                id="count"
+                name="count"
+                min="1"
+                step="1"
+                placeholder="{{defaultCount}}"
+                value=""
+                autofocus
+            />
+        </div>
+    </div>
+    {{/if}}
 </form>


### PR DESCRIPTION
Now user can drop single NPC actor and place multiple tokens for it.
1. Added `single-actor-drop-handler.ts`
2. Updated `drop-dialog.hbs`:
  a. Added count field
  b. Set autofocus on new input, so user can quickly set number
  c. Remove autofocus from drop-style if counter is presented

